### PR TITLE
Add a script for announcing the system's uptime.

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -1,9 +1,10 @@
 #Resource Monitor for NvDA
 #Presents basic info on CPU load, memory and disk usage, as well as battery information.
-#Authors: Alex Hall (core mechanics and messages), Joseph Lee (internationalization), Beqa Gozalishvili (updated psutil to 0.6.1, and made needed changes to make code run).
+#Authors: Alex Hall (core mechanics and messages), Joseph Lee (internationalization), Beqa Gozalishvili (updated psutil to 0.6.1, and made needed changes to make code run), Tuukka Ojala (uptime).
 # Copyright 2013-2017, released under GPL.
 
 import _winreg
+from datetime import datetime
 import sys
 import os
 import globalPluginHandler
@@ -173,6 +174,31 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	# Translators: Input help mode message about Windows version command in Resource Monitor.
 	script_announceWinVer.__doc__=_("Announces the version of Windows you are using.")
 
+	def getUptime(self):
+		bootTimestamp = psutil.boot_time()
+		if bootTimestamp == 0.0:
+			raise TypeError
+		uptime = datetime.now() - datetime.fromtimestamp(bootTimestamp)
+		hours, remainingMinutes = divmod(uptime.seconds, 3600)
+		minutes, seconds = divmod(remainingMinutes, 60)
+		hoursMinutesSeconds = "{hours:02}:{minutes:02}:{seconds:02}".format(hours=hours, minutes=minutes, seconds=seconds)
+		# Translators: The system's uptime
+		return _("{days} days, {hoursMinutesSeconds}").format(days=uptime.days, hoursMinutesSeconds=hoursMinutesSeconds)
+
+	def script_announceUptime(self, gesture):
+		try:
+			uptime = self.getUptime()
+			if scriptHandler.getLastScriptRepeatCount() == 0:
+				ui.message(uptime)
+			else:
+				if api.copyToClip(uptime):
+					ui.message(self.RMCopyMessage)
+		except:
+			# Translators: Obtaining uptime failed
+			ui.message(_("Failed to get the system's uptime."))
+	# Translators: Input help mode message about obtaining the system's uptime
+	script_announceUptime.__doc__=_("Announces the system's uptime.")
+
 	def script_announceResourceSummary(self, gesture):
 		# Faster to build info on the fly rather than keep appending to a string.
 		# Translators: presents the overall summary of resource usage, such as CPU load and RAM usage.
@@ -200,4 +226,5 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"KB:NVDA+shift+4":"announceBatteryInfo",
 		"KB:NVDA+shift+5":"announceRamInfo",
 		"KB:NVDA+shift+6":"announceWinVer",
+		"kb:nvda+shift+7": "announceUptime",
 	}

--- a/buildVars.py
+++ b/buildVars.py
@@ -21,7 +21,7 @@ addon_info = {
 	# version
 	"addon_version" : "17.02",
 	# Author(s)
-	"addon_author" : "Alex Hall <mehgcap@gmail.com>, Joseph Lee <joseph.lee22590@gmail.com>, beqa gozalishvili <beqaprogger@gmail.com> and other NVDA contributors",
+	"addon_author" : "Alex Hall <mehgcap@gmail.com>, Joseph Lee <joseph.lee22590@gmail.com>, beqa gozalishvili <beqaprogger@gmail.com>, Tuukka Ojala <tuukka.ojala@gmail.com> and other NVDA contributors",
 	# URL for the add-on documentation support
 	"addon_url" : "http://addons.nvda-project.org/",
 	# Documentation file name

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 [[!meta title="Resource Monitor"]]
 
-* Authors: Alex Hall, Joseph Lee, beqa gozalishvili and other NVDA contributors
+* Authors: Alex Hall, Joseph Lee, beqa gozalishvili, Tuukka Ojala and other NVDA contributors
 * Download [stable version][1]
 
 This plugin gives information about CPU load, memory usage and other resource usage information.
@@ -13,6 +13,7 @@ This plugin gives information about CPU load, memory usage and other resource us
 * NVDA+Shift+3 Presents the used and total space of the static and removable drives.
 * NVDA+Shift+4 Presents battery percentage, charging status, remaining time (if not charging), and a warning if the battery is low or critical.
 * NVDA+Shift+6 Presents  CPU Architecture 32/64-bit and Windows version and service pack numbers.
+* NVDA+Shift+7 presents the system's uptime.
 
 If you have NvDA 2013.3 or later installed, you can change these shortcut keys.
 


### PR DESCRIPTION
This PR implements a new command, NVDA+Shift+7, for announcing the system's uptime. This information might be useful to some but it can't be efficiently located with the default set of tools available.

A few gotchas:

* The format of the announcement resembles GNU Uptime's output. TO me it feels natural and efficient, but a more verbose message with hours, minutes and seconds announced separately might benefit some users. E.g. "2 days, 13:24:35" as opposed to "2 days, 13 hours, 24 minutes and 35 seconds".
* The uptime message doesn't take pluralization into account at all, e.g. the announcement is "1 days" even though it should be "1 day". I was unsure how to implement this since ngettext() doesn't seem to be used anywhere in NVDA. I'd be happy to make this better if there's an established way of handling pluralization.