### PR TITLE
Added the ability to reverse the announcements.

### DIFF
--- a/flake8.ini
+++ b/flake8.ini
@@ -7,7 +7,6 @@
 use-flake8-tabs = True
 # Not all checks are replaced by flake8-tabs, however, pycodestyle is still not compatible with tabs.
 use-pycodestyle-indent = False
-continuation-style = hanging
 ## The following are replaced by flake8-tabs plugin, reported as ET codes rather than E codes.
 # E121, E122, E123, E126, E127, E128,
 ## The following (all disabled) are not replaced by flake8-tabs,


### PR DESCRIPTION
I added the ability to reverse the announcements, E.G. instead of
Average CPU load 21.1%, Core 1: 50%, Core 2: 14.3%, Core 3: 21.4%, Core 4: 20%, Core 5: 0%, Core 6: 7.1%, Core 7: 21.4%, Core 8: 30.8%.
You hear
Average CPU idle 68%, core usage: Core 1: 18.8%, Core 2: 6.7%, Core 3: 46.7%, Core 4: 33.3%, Core 5: 13.3%, Core 6: 20%, Core 7: 66.7%, Core 8: 40%.
I've tested it and everything works, but it's worth noting that I wasn't quite sure how to handle the translators comments. Because the info string is only slightly different depending if the setting is checked or not, I only put one translators comment. Let me know if this is OK.