### PR TITLE
Fix wlan notifications

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -62,9 +62,10 @@ try:
 			return
 		match pData.contents.NotificationCode:
 			case wlanapi.wlan_notification_acm_connection_complete:
-				ssid = wlanapi.WLAN_CONNECTION_NOTIFICATION_DATA.from_address(
-					pData.contents.pData
-				).dot11Ssid.SSID
+				notificationData = wlanapi.WLAN_CONNECTION_NOTIFICATION_DATA.from_address(pData.contents.pData)
+				if notificationData.wlanReasonCode != wlanapi.ERROR_SUCCESS:
+					return
+				ssid = notificationData.dot11Ssid.SSID
 				queueHandler.queueFunction(
 					queueHandler.eventQueue,
 					message,


### PR DESCRIPTION
When Windows tries to automatically connect to Wi-Fi, addon mistakenly reports a successful connection, when in fact the connection failed.
Therefore, in this PR we check the code in the wlanReasonCode field, and report the connection only when the connection is successful.