### PR TITLE
feat: add NVIDIA GPU usage and temperature command

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -7,6 +7,8 @@
 
 import functools
 import os.path
+import shutil
+import subprocess
 import queueHandler
 import winsound
 from ctypes import addressof, byref, POINTER, wintypes
@@ -291,6 +293,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __init__(self):
 		super().__init__()
+		self._nvidiaSmiPath = None
+		self._nvidiaSmiPathResolved = False
 		if not wlanapiAvailable:
 			self._client_handle = None
 			return
@@ -314,6 +318,86 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			)
 		except OSError:
 			pass
+
+	def _findNvidiaSmiPath(self) -> str | None:
+		candidates = []
+		for commandName in ("nvidia-smi", "nvidia-smi.exe"):
+			found = shutil.which(commandName)
+			if found:
+				candidates.append(found)
+		try:
+			whereResult = subprocess.run(
+				["where.exe", "nvidia-smi"],
+				capture_output=True,
+				text=True,
+				timeout=2,
+				check=False,
+			)
+			for line in whereResult.stdout.splitlines():
+				path = line.strip().strip('"')
+				if path:
+					candidates.append(path)
+		except (OSError, subprocess.TimeoutExpired):
+			pass
+		windowsDir = os.environ.get("WINDIR", r"C:\Windows")
+		candidates.append(os.path.join(windowsDir, "System32", "nvidia-smi.exe"))
+		candidates.append(os.path.join(windowsDir, "Sysnative", "nvidia-smi.exe"))
+		for envVar in ("ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"):
+			basePath = os.environ.get(envVar)
+			if not basePath:
+				continue
+			candidates.append(
+				os.path.join(basePath, "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe")
+			)
+		seen = set()
+		for path in candidates:
+			normalizedPath = os.path.normcase(os.path.abspath(path))
+			if normalizedPath in seen:
+				continue
+			seen.add(normalizedPath)
+			if os.path.isfile(path):
+				return path
+		return None
+
+	def _getNvidiaGpuInfo(self) -> str:
+		if not self._nvidiaSmiPathResolved:
+			self._nvidiaSmiPath = self._findNvidiaSmiPath()
+			self._nvidiaSmiPathResolved = True
+		if not self._nvidiaSmiPath:
+			return _("NVIDIA SMI not available.")
+		try:
+			result = subprocess.run(
+				[
+					self._nvidiaSmiPath,
+					"--query-gpu=utilization.gpu,temperature.gpu",
+					"--format=csv,noheader,nounits",
+				],
+				capture_output=True,
+				text=True,
+				timeout=5,
+				check=True,
+			)
+		except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
+			return _("Unable to get NVIDIA GPU information.")
+		lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+		if not lines:
+			return _("No NVIDIA GPU data available.")
+		gpuInfoParts = []
+		for index, line in enumerate(lines, start=1):
+			gpuData = [part.strip() for part in line.split(",")]
+			if len(gpuData) < 2:
+				continue
+			utilization, temperature = gpuData[0], gpuData[1]
+			gpuInfoParts.append(
+				_("GPU {gpuNumber}: usage {usage}%, temp {temperature}°C.").format(
+					gpuNumber=index,
+					usage=utilization,
+					temperature=temperature,
+				)
+			)
+		if not gpuInfoParts:
+			return _("Unable to parse NVIDIA GPU information.")
+		return " ".join(gpuInfoParts)
 
 	@scriptHandler.script(
 		description=_(
@@ -451,6 +535,21 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			ui.message(info)
 		else:
 			api.copyToClip(info, notify=True)
+
+	@scriptHandler.script(
+		description=_("Announces NVIDIA GPU usage and temperature."),
+		gestures=["KB:NVDA+shift+9", "KB:NVDA+shift+numpad9"],
+		speakOnDemand=True,
+	)
+	def script_announceNvidiaGpuInfo(self, gesture):
+		try:
+			info = self._getNvidiaGpuInfo()
+			if scriptHandler.getLastScriptRepeatCount() == 0:
+				ui.message(info)
+			else:
+				api.copyToClip(info, notify=True)
+		except Exception:
+			ui.message(_("Failed to get NVIDIA GPU information."))
 
 	def _getWlanInfo(self) -> str:
 		if not self._client_handle:

--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -359,12 +359,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				return path
 		return None
 
-	def _getNvidiaGpuInfo(self) -> str:
+	def _getGpuInfo(self) -> str:
 		if not self._nvidiaSmiPathResolved:
 			self._nvidiaSmiPath = self._findNvidiaSmiPath()
 			self._nvidiaSmiPathResolved = True
 		if not self._nvidiaSmiPath:
-			return _("NVIDIA SMI not available.")
+			# Translators: Message reported when GPU telemetry cannot be obtained on this system.
+			return _("No GPU information available.")
 		try:
 			result = subprocess.run(
 				[
@@ -378,10 +379,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				check=True,
 			)
 		except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
-			return _("Unable to get NVIDIA GPU information.")
+			# Translators: Message reported when GPU telemetry retrieval fails.
+			return _("Unable to get GPU information.")
 		lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
 		if not lines:
-			return _("No NVIDIA GPU data available.")
+			# Translators: Message reported when no GPU data entries are returned.
+			return _("No GPU data available.")
 		gpuInfoParts = []
 		for index, line in enumerate(lines, start=1):
 			gpuData = [part.strip() for part in line.split(",")]
@@ -389,6 +392,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				continue
 			utilization, temperature = gpuData[0], gpuData[1]
 			gpuInfoParts.append(
+				# Translators: Reports load and temperature for one GPU.
 				_("GPU {gpuNumber}: usage {usage}%, temp {temperature}°C.").format(
 					gpuNumber=index,
 					usage=utilization,
@@ -396,7 +400,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				)
 			)
 		if not gpuInfoParts:
-			return _("Unable to parse NVIDIA GPU information.")
+			# Translators: Message reported when GPU output format is not recognized.
+			return _("Unable to parse GPU information.")
 		return " ".join(gpuInfoParts)
 
 	@scriptHandler.script(
@@ -537,19 +542,21 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			api.copyToClip(info, notify=True)
 
 	@scriptHandler.script(
-		description=_("Announces NVIDIA GPU usage and temperature."),
-		gestures=["KB:NVDA+shift+9", "KB:NVDA+shift+numpad9"],
+		# Translators: Input help mode message about GPU usage and temperature command.
+		description=_("Announces GPU usage and temperature."),
+		gestures=["KB:NVDA+shift+0", "KB:NVDA+shift+numpad0"],
 		speakOnDemand=True,
 	)
-	def script_announceNvidiaGpuInfo(self, gesture):
+	def script_announceGpuInfo(self, gesture):
 		try:
-			info = self._getNvidiaGpuInfo()
+			info = self._getGpuInfo()
 			if scriptHandler.getLastScriptRepeatCount() == 0:
 				ui.message(info)
 			else:
 				api.copyToClip(info, notify=True)
 		except Exception:
-			ui.message(_("Failed to get NVIDIA GPU information."))
+			# Translators: Message reported when the GPU command fails unexpectedly.
+			ui.message(_("Failed to get GPU information."))
 
 	def _getWlanInfo(self) -> str:
 		if not self._client_handle:

--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -7,8 +7,6 @@
 
 import functools
 import os.path
-import shutil
-import subprocess
 import queueHandler
 import winsound
 from ctypes import addressof, byref, POINTER, wintypes
@@ -29,6 +27,7 @@ try:
 except OSError:
 	wlanapiAvailable = False
 import addonHandler
+from .gpu import BaseGpuProvider, getGpuProviders
 
 addonHandler.initTranslation()
 
@@ -293,8 +292,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __init__(self):
 		super().__init__()
-		self._nvidiaSmiPath = None
-		self._nvidiaSmiPathResolved = False
+		self._gpuProviders: list[BaseGpuProvider] = getGpuProviders()
 		if not wlanapiAvailable:
 			self._client_handle = None
 			return
@@ -319,90 +317,34 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		except OSError:
 			pass
 
-	def _findNvidiaSmiPath(self) -> str | None:
-		candidates = []
-		for commandName in ("nvidia-smi", "nvidia-smi.exe"):
-			found = shutil.which(commandName)
-			if found:
-				candidates.append(found)
-		try:
-			whereResult = subprocess.run(
-				["where.exe", "nvidia-smi"],
-				capture_output=True,
-				text=True,
-				timeout=2,
-				check=False,
-			)
-			for line in whereResult.stdout.splitlines():
-				path = line.strip().strip('"')
-				if path:
-					candidates.append(path)
-		except (OSError, subprocess.TimeoutExpired):
-			pass
-		windowsDir = os.environ.get("WINDIR", r"C:\Windows")
-		candidates.append(os.path.join(windowsDir, "System32", "nvidia-smi.exe"))
-		candidates.append(os.path.join(windowsDir, "Sysnative", "nvidia-smi.exe"))
-		for envVar in ("ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"):
-			basePath = os.environ.get(envVar)
-			if not basePath:
-				continue
-			candidates.append(
-				os.path.join(basePath, "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe")
-			)
-		seen = set()
-		for path in candidates:
-			normalizedPath = os.path.normcase(os.path.abspath(path))
-			if normalizedPath in seen:
-				continue
-			seen.add(normalizedPath)
-			if os.path.isfile(path):
-				return path
-		return None
-
 	def _getGpuInfo(self) -> str:
-		if not self._nvidiaSmiPathResolved:
-			self._nvidiaSmiPath = self._findNvidiaSmiPath()
-			self._nvidiaSmiPathResolved = True
-		if not self._nvidiaSmiPath:
-			# Translators: Message reported when GPU telemetry cannot be obtained on this system.
-			return _("No GPU information available.")
-		try:
-			result = subprocess.run(
-				[
-					self._nvidiaSmiPath,
-					"--query-gpu=utilization.gpu,temperature.gpu",
-					"--format=csv,noheader,nounits",
-				],
-				capture_output=True,
-				text=True,
-				timeout=5,
-				check=True,
-			)
-		except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
-			# Translators: Message reported when GPU telemetry retrieval fails.
-			return _("Unable to get GPU information.")
-		lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-		if not lines:
-			# Translators: Message reported when no GPU data entries are returned.
-			return _("No GPU data available.")
-		gpuInfoParts = []
-		for index, line in enumerate(lines, start=1):
-			gpuData = [part.strip() for part in line.split(",")]
-			if len(gpuData) < 2:
+		hasProvider = False
+		hasFailure = False
+		for provider in self._gpuProviders:
+			telemetry = provider.collect()
+			if telemetry is None:
 				continue
-			utilization, temperature = gpuData[0], gpuData[1]
-			gpuInfoParts.append(
-				# Translators: Reports load and temperature for one GPU.
-				_("GPU {gpuNumber}: usage {usage}%, temp {temperature}°C.").format(
-					gpuNumber=index,
-					usage=utilization,
-					temperature=temperature,
+			hasProvider = True
+			if not telemetry:
+				hasFailure = True
+				continue
+			gpuInfoParts = []
+			for index, item in enumerate(telemetry, start=1):
+				gpuInfoParts.append(
+					_("GPU {gpuNumber}: usage {usage}%, temp {temperature}°C.").format(
+						gpuNumber=index,
+						usage=item.utilization,
+						temperature=item.temperature,
+					)
 				)
-			)
-		if not gpuInfoParts:
-			# Translators: Message reported when GPU output format is not recognized.
-			return _("Unable to parse GPU information.")
-		return " ".join(gpuInfoParts)
+			if gpuInfoParts:
+				return " ".join(gpuInfoParts)
+			hasFailure = True
+		if not hasProvider:
+			return _("No GPU information available.")
+		if hasFailure:
+			return _("Unable to get GPU information.")
+		return _("No GPU data available.")
 
 	@scriptHandler.script(
 		description=_(
@@ -544,7 +486,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@scriptHandler.script(
 		# Translators: Input help mode message about GPU usage and temperature command.
 		description=_("Announces GPU usage and temperature."),
-		gestures=["KB:NVDA+shift+0", "KB:NVDA+shift+numpad0"],
 		speakOnDemand=True,
 	)
 	def script_announceGpuInfo(self, gesture):

--- a/addon/globalPlugins/resourceMonitor/gpu.py
+++ b/addon/globalPlugins/resourceMonitor/gpu.py
@@ -1,0 +1,97 @@
+import os
+import os.path
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class GpuTelemetry:
+	utilization: str
+	temperature: str
+
+
+class BaseGpuProvider:
+	def collect(self) -> list[GpuTelemetry] | None:
+		raise NotImplementedError
+
+
+class NvidiaGpuProvider(BaseGpuProvider):
+	def __init__(self):
+		self._nvidiaSmiPath = None
+		self._nvidiaSmiPathResolved = False
+
+	def _findNvidiaSmiPath(self) -> str | None:
+		candidates = []
+		for commandName in ("nvidia-smi", "nvidia-smi.exe"):
+			found = shutil.which(commandName)
+			if found:
+				candidates.append(found)
+		try:
+			whereResult = subprocess.run(
+				["where.exe", "nvidia-smi"],
+				capture_output=True,
+				text=True,
+				timeout=2,
+				check=False,
+			)
+			for line in whereResult.stdout.splitlines():
+				path = line.strip().strip('"')
+				if path:
+					candidates.append(path)
+		except (OSError, subprocess.TimeoutExpired):
+			pass
+		windowsDir = os.environ.get("WINDIR", r"C:\Windows")
+		candidates.append(os.path.join(windowsDir, "System32", "nvidia-smi.exe"))
+		candidates.append(os.path.join(windowsDir, "Sysnative", "nvidia-smi.exe"))
+		for envVar in ("ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"):
+			basePath = os.environ.get(envVar)
+			if not basePath:
+				continue
+			candidates.append(
+				os.path.join(basePath, "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe")
+			)
+		seen = set()
+		for path in candidates:
+			normalizedPath = os.path.normcase(os.path.abspath(path))
+			if normalizedPath in seen:
+				continue
+			seen.add(normalizedPath)
+			if os.path.isfile(path):
+				return path
+		return None
+
+	def collect(self) -> list[GpuTelemetry] | None:
+		if not self._nvidiaSmiPathResolved:
+			self._nvidiaSmiPath = self._findNvidiaSmiPath()
+			self._nvidiaSmiPathResolved = True
+		if not self._nvidiaSmiPath:
+			return None
+		try:
+			result = subprocess.run(
+				[
+					self._nvidiaSmiPath,
+					"--query-gpu=utilization.gpu,temperature.gpu",
+					"--format=csv,noheader,nounits",
+				],
+				capture_output=True,
+				text=True,
+				timeout=5,
+				check=True,
+			)
+		except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
+			return []
+		lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+		if not lines:
+			return []
+		items: list[GpuTelemetry] = []
+		for line in lines:
+			gpuData = [part.strip() for part in line.split(",")]
+			if len(gpuData) < 2:
+				continue
+			items.append(GpuTelemetry(utilization=gpuData[0], temperature=gpuData[1]))
+		return items
+
+
+def getGpuProviders() -> list[BaseGpuProvider]:
+	return [NvidiaGpuProvider()]


### PR DESCRIPTION
## Summary
- add a new command to announce NVIDIA GPU usage and temperature using `nvidia-smi`
- resolve `nvidia-smi` path lazily on first request to avoid startup overhead for users who do not use this command
- keep the implementation NVIDIA-only for now because AMD tooling does not provide a single stable path on Windows

## Test plan
- [x] build add-on with `scons`
- [ ] run NVDA and trigger `NVDA+Shift+9`
- [ ] verify first execution discovers `nvidia-smi` and announces GPU usage/temperature
- [ ] verify repeated execution still works and second press copies result to clipboard
- [ ] verify behavior on a machine without NVIDIA tooling returns a clear unavailable message