### PR TITLE
Report mapped network drive status in drive info command (NVDA+Shift+3)

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -366,34 +366,50 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@scriptHandler.script(
 		# Translators: Input help message about drive info command in Resource Monitor.
 		description=_(
-			"Presents the used and total space of the fixed (built-in) and removable drives on this computer. "
+			"Presents the used and total space of the fixed (built-in), removable, and mapped network drives on this computer. "
 			"If pressed twice, copies the information to the clipboard."
 		),
 		gesture="KB:NVDA+shift+3",
 		speakOnDemand=True,
 	)
 	def script_announceDriveInfo(self, gesture: inputCore.InputGesture):
-		# Goes through all registered drives and gives info on each one
+		# Goes through all registered drives, including mapped network drives, and gives info on each one.
+		# psutil.disk_partitions() defaults to all=False, which silently excludes mapped network
+		# drives on Windows (they're not considered "physical" devices). Passing all=True brings
+		# them back in.
 		info = []
-		for drive in psutil.disk_partitions():
-			# Get info on each one
-			# If and only if the Windows says disk is ready in order to avoid
-			# a core stack freeze when no disk is inserted into a slot.
+		for drive in psutil.disk_partitions(all=True):
+			# Get info on each one.
+			# If and only if Windows says the disk is ready do we query it, in order to avoid
+			# a core stack freeze when no disk is inserted into a slot, or a mapped network
+			# drive has never been connected.
 			# This can be checked by looking for a file system.
-			if drive.fstype:
+			if not drive.fstype:
+				continue
+			isNetworkDrive = "remote" in drive.opts.split(",")
+			try:
 				driveInfo = psutil.disk_usage(drive[0])
-				info.append(
-					# Translators: Shows drive letter, type of drive (fixed or removable),
-					# used capacity and total capacity of a drive
-					# (example: C drive, ntfs; 40 GB of 100 GB used (40%).
-					_("{driveName} ({driveType} drive): {usedSpace} of {totalSpace} used ({percent}%).").format(
-						driveName=drive[0],
-						driveType=drive[2],
-						usedSpace=size(driveInfo[1], alternative),
-						totalSpace=size(driveInfo[0], alternative),
-						percent=tryTrunk(driveInfo[3]),
-					)
+			except OSError:
+				# The drive is registered but currently can't be reached, e.g. an offline
+				# mapped network drive whose host is unreachable.
+				if isNetworkDrive:
+					# Translators: Reported when a mapped network drive is currently unreachable.
+					info.append(_("{driveName} (network drive): not available.").format(driveName=drive[0]))
+				continue
+			# Translators: word used to describe a mapped network drive.
+			driveType = _("network") if isNetworkDrive else drive[2]
+			info.append(
+				# Translators: Shows drive letter, type of drive (fixed, removable, or network),
+				# used capacity and total capacity of a drive
+				# (example: C drive, ntfs; 40 GB of 100 GB used (40%).
+				_("{driveName} ({driveType} drive): {usedSpace} of {totalSpace} used ({percent}%).").format(
+					driveName=drive[0],
+					driveType=driveType,
+					usedSpace=size(driveInfo[1], alternative),
+					totalSpace=size(driveInfo[0], alternative),
+					percent=tryTrunk(driveInfo[3]),
 				)
+			)
 		if scriptHandler.getLastScriptRepeatCount() == 0:
 			ui.message(" ".join(info))
 		else:


### PR DESCRIPTION
## Summary

`script_announceDriveInfo` (NVDA+Shift+3) silently skipped mapped network drives. This was because it called `psutil.disk_partitions()` with the default `all=False`, and psutil's Windows backend explicitly excludes `DRIVE_REMOTE` (mapped network drives) in that mode. They aren't considered "physical" devices.

## Changes

* Switched to `psutil.disk_partitions(all=True)` so mapped network drives are included in the enumeration.
* Detect network drives via `drive.opts` (contains `"remote"`) and label them accordingly instead of showing a filesystem type.
* Wrapped `psutil.disk_usage()` in `try/except OSError` so an offline or unreachable mapped network drive is announced as "not available" instead of raising an error.
* Updated the command's input-help description to mention network drives.

## Notes / caveats

* The existing `if not drive.fstype` guard (originally there to avoid a freeze on an empty CD-ROM drive) still applies, and also now covers network drives that have never successfully connected.
* If a mapped drive's host is reachable but slow, the underlying Windows volume query can still block for a while before failing. This is Windows/psutil-level behavior and isn't something the add-on can fully prevent.

Closes #58