### PR TITLE
Add GPU temperature unit setting (Celsius/Fahrenheit)

### DIFF
--- a/addon/globalPlugins/resourceMonitor/__init__.py
+++ b/addon/globalPlugins/resourceMonitor/__init__.py
@@ -12,13 +12,16 @@ from ctypes import addressof, byref, POINTER, wintypes
 from datetime import datetime
 from typing import Any
 import api
+import config
 import globalPluginHandler
 import queueHandler
 import scriptHandler
 import inputCore
 import ui
 import winVersion
-from gui import blockAction
+import wx
+from gui import blockAction, guiHelper
+from gui.settingsDialogs import NVDASettingsDialog, SettingsPanel
 import psutil
 
 # Windows Server systems prior to Server 2025 do not include wlanapi.dll.
@@ -35,6 +38,12 @@ addonHandler.initTranslation()
 
 
 MODULE_DIR = os.path.dirname(__file__)
+
+# Register this add-on's settings with NVDA's configuration system.
+confspec = {
+	"gpuTempUnit": "string(default=celsius)",
+}
+config.conf.spec["resourceMonitor"] = confspec
 
 
 def message(text: str, fileName: str) -> None:
@@ -205,6 +214,54 @@ def tryTrunk(n: float) -> int | float:
 	return n
 
 
+def formatGpuTemperature(celsiusText: str) -> str:
+	# GPU providers report temperature in degrees Celsius as text.
+	# Convert it to the user's preferred unit (Celsius or Fahrenheit) for display.
+	try:
+		celsius = float(celsiusText)
+	except (TypeError, ValueError):
+		return celsiusText
+	unit = config.conf["resourceMonitor"]["gpuTempUnit"]
+	if unit == "fahrenheit":
+		value = celsius * 9.0 / 5.0 + 32.0
+		# Translators: Fahrenheit temperature unit symbol appended to a GPU temperature value.
+		symbol = _("degrees Fahrenheit")
+	else:
+		value = celsius
+		# Translators: Celsius temperature unit symbol appended to a GPU temperature value.
+		symbol = _("degrees Celsius")
+	return "{} {}".format(tryTrunk(round(value, 1)), symbol)
+
+
+class ResourceMonitorSettingsPanel(SettingsPanel):
+	# Translators: Category title for Resource Monitor settings in NVDA's settings dialog.
+	title = _("Resource Monitor")
+
+	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
+		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		# Translators: Label for a combo box to select the unit used to report GPU temperature.
+		gpuTempUnitLabelText = _("GPU &temperature unit:")
+		# Translators: An option in the GPU temperature unit combo box.
+		self._gpuTempUnitLabels = [_("Celsius"), _("Fahrenheit")]
+		self._gpuTempUnitValues = ["celsius", "fahrenheit"]
+		self.gpuTempUnitList = settingsSizerHelper.addLabeledControl(
+			gpuTempUnitLabelText,
+			wx.Choice,
+			choices=self._gpuTempUnitLabels,
+		)
+		try:
+			currentIndex = self._gpuTempUnitValues.index(config.conf["resourceMonitor"]["gpuTempUnit"])
+		except ValueError:
+			currentIndex = 0
+		self.gpuTempUnitList.SetSelection(currentIndex)
+
+	def onSave(self) -> None:
+		selection = self.gpuTempUnitList.GetSelection()
+		if selection == wx.NOT_FOUND:
+			selection = 0
+		config.conf["resourceMonitor"]["gpuTempUnit"] = self._gpuTempUnitValues[selection]
+
+
 @functools.lru_cache(maxsize=1)
 def getWinVer() -> str:
 	# Obtain current Windows version.
@@ -235,6 +292,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def __init__(self):
 		super().__init__()
 		self._gpuProviders: list[BaseGpuProvider] = getGpuProviders()
+		NVDASettingsDialog.categoryClasses.append(ResourceMonitorSettingsPanel)
 		if not wlanapiAvailable:
 			self._client_handle = None
 			return
@@ -262,6 +320,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def terminate(self):
 		super().terminate()
 		self._gpuProviders.clear()
+		if ResourceMonitorSettingsPanel in NVDASettingsDialog.categoryClasses:
+			NVDASettingsDialog.categoryClasses.remove(ResourceMonitorSettingsPanel)
 		if not self._client_handle:
 			return
 		self._negotiated_version = None
@@ -546,10 +606,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			gpuInfoParts = []
 			for index, item in enumerate(telemetry, start=1):
 				gpuInfoParts.append(
-					_("GPU {gpuNumber}: usage {usage}%, temp {temperature}°C.").format(
+					_("GPU {gpuNumber}: usage {usage}%, temp {temperature}.").format(
 						gpuNumber=index,
 						usage=item.utilization,
-						temperature=item.temperature,
+						temperature=formatGpuTemperature(item.temperature),
 					)
 				)
 			if gpuInfoParts:

--- a/buildVars.py
+++ b/buildVars.py
@@ -26,11 +26,8 @@ addon_info = AddonInfo(
 	addon_version="26.07",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
-	addon_changelog=_("""* Removed add-on changelog from add-on help (readme) file.
-* Changed CPU load and wireless network status announcements to show average CPU load percentage first and made network status reporting less verbose, respectively.
-* NVDA will no longer repeat wireless network status announcements when the add-on is reloaded without first restarting NVDA (Control+NVDA+F3).
-* NVDA will no longer announce GPU information in secure screens due to how the feature works internally.
-* Battery status anouncement command (NVDA+Shift+4) and announcing battery info as part of the overall resource usage information (NVDA+Shift+E) are deprecated and will be removed in a future add-on release (NVDA provides its own battery status command (NVDA+Shift+B))."""),
+	addon_changelog=_("""* Pressing NVDA+Shift+3 to report disk usage information will include mapped network drives if connected (contributed by hexxbyte).
+* Removed battery status reporting feature. Pressing NVDA+Shift+4 will now report wireless connection status."""),
 	# Author(s)
 	addon_author="Alex Hall <mehgcap@gmail.com>, Joseph Lee <joseph.lee22590@gmail.com>, Kefas Lungu <jameskefaslungu@gmail.com>, beqa gozalishvili <beqaprogger@gmail.com>, Tuukka Ojala <tuukka.ojala@gmail.com>, Ethin Probst <harlydavidsen@gmail.com>, Kevin Derome, Jonathan Rodriguez <jonathantrodriguez6@gmail.com> and other NVDA contributors",
 	# URL for the add-on documentation support

--- a/buildVars.py
+++ b/buildVars.py
@@ -32,7 +32,7 @@ addon_info = AddonInfo(
 * NVDA will no longer announce GPU information in secure screens due to how the feature works internally.
 * Battery status anouncement command (NVDA+Shift+4) and announcing battery info as part of the overall resource usage information (NVDA+Shift+E) are deprecated and will be removed in a future add-on release (NVDA provides its own battery status command (NVDA+Shift+B))."""),
 	# Author(s)
-	addon_author="Alex Hall <mehgcap@gmail.com>, Joseph Lee <joseph.lee22590@gmail.com>, Kefas Lungu <jameskefaslungu@gmail.com>, beqa gozalishvili <beqaprogger@gmail.com>, Tuukka Ojala <tuukka.ojala@gmail.com>, Ethin Probst <harlydavidsen@gmail.com>, Kevin Derome and other NVDA contributors",
+	addon_author="Alex Hall <mehgcap@gmail.com>, Joseph Lee <joseph.lee22590@gmail.com>, Kefas Lungu <jameskefaslungu@gmail.com>, beqa gozalishvili <beqaprogger@gmail.com>, Tuukka Ojala <tuukka.ojala@gmail.com>, Ethin Probst <harlydavidsen@gmail.com>, Kevin Derome, Jonathan Rodriguez <jonathantrodriguez6@gmail.com> and other NVDA contributors",
 	# URL for the add-on documentation support
 	addon_url="https://github.com/kefaslungu/resourceMonitor",
 	# URL for the add-on repository where the source code can be found

--- a/changes.md
+++ b/changes.md
@@ -4,6 +4,7 @@ This page lists the complete changelog for Resource Monitor add-on releases.
 
 ## Version 26.08
 
+* Pressing NVDA+Shift+3 to report disk usage information will include mapped network drives if connected (contributed by hexxbyte).
 * Removed battery status reporting feature. Pressing NVDA+Shift+4 will now report wireless connection status.
 
 ## Version 26.07

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ All commands support speech on demand mode.
 * NVDA+Shift+E: presents used RAM (pyysical memory) and average processor load.
 * NVDA+Shift+1: presents the average processor load and if multicore CPU's are present the load of each core.
 * NVDA+Shift+2/5: presents the used and total space for both physical and virtual RAM (NVDA+Shift+5 is an alternative to NVDA+Shift+2 when the latter keyboard combination cannot be performed).
-* NVDA+Shift+3: presents the used and total space of the fixed (built-in) and removable drives.
+* NVDA+Shift+3: presents the used and total space of the fixed (built-in), removable, and network drives.
 * NVDA+Shift+4: presents information on the wireless connection, network (SSID) name and strength, or no SSID if there is none available.
 * NVDA+Shift+6: presents  Windows version, CPU architecture, and exact build number (build.revision).
 * NVDA+Shift+7: presents the system's uptime.
@@ -26,7 +26,7 @@ This add-on does not replace task manager and other system information programs 
 * Apart from overall resource usage command (NVDA+Shift+E), pressing other commands twice will copy resource usage information to the clipboard.
 * Resource information cannot be copied to the clipboard if running the add-on in secure screens.
 * CPU usage is given for logical processors, not physical cores. This is noticeable for processors which uses Hyper-Threading where number of CPU's is twice the number of CPU cores. On some newer computers, not all CPU cores will have hyper-threading enabled.
-* If there is heavy disk activity such as copying large files, there might be delays when obtaining disk usage information.
+* If there is heavy disk activity such as copying large files or while locating network drives, there might be delays when obtaining disk usage information.
 * When announcing processor architecture information, "x86" and "AMD64" refer to 32-bit and 64-bit (x64) Intel and AMD processors, respectively.
 * Installing the add-on on Windows 10/11 LTSC is not supported.
 


### PR DESCRIPTION
## Summary
Adds a new "Resource Monitor" settings category (NVDA menu ? Preferences ? Settings) with a combo box letting users choose whether GPU temperature is reported in Celsius or Fahrenheit.

## Changes
* New `ResourceMonitorSettingsPanel` (subclass of NVDA's `SettingsPanel`), registered into `NVDASettingsDialog.categoryClasses` on plugin `__init__` and removed on `terminate`.
* New confspec entry `resourceMonitor.gpuTempUnit` (`celsius` / `fahrenheit`, default `celsius`), persisted via NVDA's `config.ini`.
* New `formatGpuTemperature()` helper that converts the raw Celsius value returned by GPU providers (e.g. `nvidia-smi`) into the user's selected unit before it's spoken/copied.
* `_getGpuInfo()` / `script_announceGpuInfo` updated to use the new formatter instead of a hardcoded `°C`.

## Notes
* No changes to existing default gestures.
* Default behavior unchanged (Celsius) for users who don't touch the new setting.